### PR TITLE
replace `uq` with `Ki` prefix

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use crate::{Address as uqAddress, Request as uqRequest};
+use crate::{Address as KiAddress, Request as KiRequest};
 use alloy_rpc_types::Log;
 pub use ethers_core::types::{
     Address as EthAddress, BlockNumber, Filter, FilterBlockOption, Topic, ValueOrArray, H256, U64,
@@ -44,7 +44,7 @@ pub enum EthSubEvent {
 
 #[derive(Debug)]
 pub struct SubscribeLogsRequest {
-    pub request: uqRequest,
+    pub request: KiRequest,
     pub id: u64,
     pub filter: Filter,
 }
@@ -52,7 +52,7 @@ pub struct SubscribeLogsRequest {
 impl SubscribeLogsRequest {
     /// Start building a new `SubscribeLogsRequest`.
     pub fn new(id: u64) -> Self {
-        let request = uqRequest::new().target(uqAddress::new(
+        let request = KiRequest::new().target(KiAddress::new(
             "our",
             ProcessId::new(Some("eth"), "distro", "sys"),
         ));

--- a/src/vfs/mod.rs
+++ b/src/vfs/mod.rs
@@ -12,7 +12,7 @@ pub use file::*;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VfsRequest {
     /// path is always prepended by package_id, the capabilities of the topmost folder are checked
-    /// "/your_package:publisher.uq/drive_folder/another_folder_or_file"
+    /// "/your_package:publisher.os/drive_folder/another_folder_or_file"
     pub path: String,
     pub action: VfsAction,
 }


### PR DESCRIPTION
Replace `uq`s in code with either `os` (for TLD) or `Ki` prefix.