### PR TITLE
Update and fix serve_ui and serve_index_html

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.5.5"
+version = "0.5.7"
 dependencies = [
  "alloy-rpc-types",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinode_process_lib"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 
 [features]

--- a/src/http.rs
+++ b/src/http.rs
@@ -500,7 +500,8 @@ pub fn send_request_await_response(
             error: "http_client timed out".to_string(),
         });
     };
-    let Ok(HttpClientResponse::Http(resp)) = serde_json::from_slice::<HttpClientResponse>(&body) else {
+    let Ok(HttpClientResponse::Http(resp)) = serde_json::from_slice::<HttpClientResponse>(&body)
+    else {
         return Err(HttpClientError::RequestFailed {
             error: "http_client gave unexpected response".to_string(),
         });
@@ -591,9 +592,10 @@ pub fn serve_ui(
                 path,
                 action: VfsAction::ReadDir,
             })?)
-            .send_and_await_response(5)? else {
-                return Err(anyhow::anyhow!("serve_ui: no response for path"));
-            };
+            .send_and_await_response(5)?
+        else {
+            return Err(anyhow::anyhow!("serve_ui: no response for path"));
+        };
 
         let directory_body = serde_json::from_slice::<VfsResponse>(directory_response.body())?;
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -699,18 +699,20 @@ pub fn open_ws_connection(
     headers: Option<HashMap<String, String>>,
     channel_id: u32,
 ) -> std::result::Result<(), HttpClientError> {
-    let Ok(Ok(Message::Response { body, .. })) = KiRequest::to(("our", "http_client", "distro", "sys"))
-        .body(
-            serde_json::to_vec(&HttpClientAction::WebSocketOpen {
-                url: url.clone(),
-                headers: headers.unwrap_or(HashMap::new()),
-                channel_id,
-            })
-            .unwrap(),
-        )
-        .send_and_await_response(5) else {
-            return Err(HttpClientError::WsOpenFailed { url });
-        };
+    let Ok(Ok(Message::Response { body, .. })) =
+        KiRequest::to(("our", "http_client", "distro", "sys"))
+            .body(
+                serde_json::to_vec(&HttpClientAction::WebSocketOpen {
+                    url: url.clone(),
+                    headers: headers.unwrap_or(HashMap::new()),
+                    channel_id,
+                })
+                .unwrap(),
+            )
+            .send_and_await_response(5)
+    else {
+        return Err(HttpClientError::WsOpenFailed { url });
+    };
     match serde_json::from_slice(&body) {
         Ok(Ok(HttpClientResponse::WebSocketAck)) => Ok(()),
         Ok(Err(e)) => Err(e),
@@ -733,16 +735,18 @@ pub fn send_ws_client_push(channel_id: u32, message_type: WsMessageType, blob: K
 }
 
 pub fn close_ws_connection(channel_id: u32) -> std::result::Result<(), HttpClientError> {
-    let Ok(Ok(Message::Response { body, .. })) = KiRequest::to(("our", "http_client", "distro", "sys"))
-        .body(
-            serde_json::json!(HttpClientAction::WebSocketClose { channel_id })
-                .to_string()
-                .as_bytes()
-                .to_vec(),
-        )
-        .send_and_await_response(5) else {
-            return Err(HttpClientError::WsCloseFailed { channel_id });
-        };
+    let Ok(Ok(Message::Response { body, .. })) =
+        KiRequest::to(("our", "http_client", "distro", "sys"))
+            .body(
+                serde_json::json!(HttpClientAction::WebSocketClose { channel_id })
+                    .to_string()
+                    .as_bytes()
+                    .to_vec(),
+            )
+            .send_and_await_response(5)
+    else {
+        return Err(HttpClientError::WsCloseFailed { channel_id });
+    };
     match serde_json::from_slice(&body) {
         Ok(Ok(HttpClientResponse::WebSocketAck)) => Ok(()),
         Ok(Err(e)) => Err(e),

--- a/src/http.rs
+++ b/src/http.rs
@@ -546,7 +546,7 @@ pub fn serve_index_html(
     directory: &str,
     authenticated: bool,
     local_only: bool,
-    paths: Option<Vec<&str>>,
+    paths: Vec<&str>,
 ) -> anyhow::Result<()> {
     KiRequest::to(("our", "vfs", "distro", "sys"))
         .body(serde_json::to_vec(&VfsRequest {
@@ -560,12 +560,6 @@ pub fn serve_index_html(
     };
 
     let index = String::from_utf8(blob.bytes)?;
-
-    // Paths defaults to the root path
-    let paths = match paths {
-        Some(paths) => paths,
-        None => vec!["/"],
-    };
 
     for path in paths {
         bind_http_static_path(
@@ -587,7 +581,7 @@ pub fn serve_ui(
     directory: &str,
     authenticated: bool,
     local_only: bool,
-    paths: Option<Vec<&str>>,
+    paths: Vec<&str>,
 ) -> anyhow::Result<()> {
     serve_index_html(our, directory, authenticated, local_only, paths)?;
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -546,6 +546,7 @@ pub fn serve_index_html(
     directory: &str,
     authenticated: bool,
     local_only: bool,
+    paths: Option<Vec<&str>>,
 ) -> anyhow::Result<()> {
     KiRequest::to(("our", "vfs", "distro", "sys"))
         .body(serde_json::to_vec(&VfsRequest {
@@ -560,14 +561,23 @@ pub fn serve_index_html(
 
     let index = String::from_utf8(blob.bytes)?;
 
-    // index.html will be served from the root path of your app
-    Ok(bind_http_static_path(
-        "/",
-        authenticated,
-        local_only,
-        Some("text/html".to_string()),
-        index.to_string().as_bytes().to_vec(),
-    )?)
+    // Paths defaults to the root path
+    let paths = match paths {
+        Some(paths) => paths,
+        None => vec!["/"],
+    };
+
+    for path in paths {
+        bind_http_static_path(
+            path,
+            authenticated,
+            local_only,
+            Some("text/html".to_string()),
+            index.to_string().as_bytes().to_vec(),
+        )?;
+    }
+
+    Ok(())
 }
 
 /// Serve static files from a given directory by binding all of them
@@ -577,7 +587,10 @@ pub fn serve_ui(
     directory: &str,
     authenticated: bool,
     local_only: bool,
+    paths: Option<Vec<&str>>,
 ) -> anyhow::Result<()> {
+    serve_index_html(our, directory, authenticated, local_only, paths)?;
+
     let initial_path = format!("{}/pkg/{}", our.package_id(), directory);
 
     let mut queue = VecDeque::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,15 @@ pub fn spawn(
     )
 }
 
+impl std::default::Default for LazyLoadBlob {
+    fn default() -> Self {
+        LazyLoadBlob {
+            mime: None,
+            bytes: Vec::new(),
+        }
+    }
+}
+
 /// Create a blob with no MIME type and a generic type, plus a serializer
 /// function that turns that type into bytes.
 ///


### PR DESCRIPTION
The goal here is to allow the server to serve multiple routes for the UI, so that the UI can use browser routing.

How this works:
1. The server responds to a specified route like `/users` with the UI
2. The UI routes the user to the correct page/view within the web app