### PR TITLE
http: update `bind_ext_path()` comment

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -451,9 +451,9 @@ where
     resp
 }
 
-/// Register a WebSockets path with the HTTP server specifically for sending and
-/// receiving system messages from a runtime extension. Only use this if you are
-/// writing a runtime extension.
+/// Register a WebSockets path with the HTTP server to send and
+/// receive system messages from a runtime extension. Only use
+/// this if you are writing a runtime extension.
 pub fn bind_ext_path<T>(path: T) -> std::result::Result<(), HttpServerError>
 where
     T: Into<String>,


### PR DESCRIPTION
Slight change to the comment. Note that the current implementation means that this ext websocket can support both the ext AND FE with the same WS. Depending on decisions we make in the future wrt security, this may need to change; but this is the current behavior.