### PR TITLE
Updates to IncomingHttpRequest

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,15 @@
+## Problem
+
+{A brief description of the problem, along with necessary context.}
+
+## Solution
+
+{A brief description of how you solved the problem.}
+
+## Docs Update
+
+[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/my-pr-number)
+
+## Notes
+
+{Any other information useful for reviewers.}

--- a/src/http.rs
+++ b/src/http.rs
@@ -235,10 +235,16 @@ impl IncomingHttpRequest {
         }
     }
 
-    pub fn bound_path(&self, strip_prefix: Option<&str>) -> String {
-        self.bound_path
-            .replace(strip_prefix.unwrap_or(""), "")
-            .replace("//", "/")
+    /// Returns the path that was originally bound, with an optional prefix stripped.
+    /// The prefix would normally be the process ID as a &str, but it could be anything.
+    pub fn bound_path(&self, process_id_to_strip: Option<&str>) -> &str {
+        match process_id_to_strip {
+            Some(process_id) => self
+                .bound_path
+                .strip_prefix(&format!("/{}", process_id))
+                .unwrap_or(&self.bound_path),
+            None => &self.bound_path,
+        }
     }
 
     pub fn path(&self) -> anyhow::Result<String> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -44,7 +44,9 @@ pub struct IncomingHttpRequest {
     source_socket_addr: Option<String>, // will parse to SocketAddr
     method: String,                     // will parse to http::Method
     url: String,                        // will parse to url::Url
+    bound_path: String,                 // the matching path that was bound
     headers: HashMap<String, String>,   // will parse to http::HeaderMap
+    url_params: HashMap<String, String>,
     query_params: HashMap<String, String>,
     // BODY is stored in the lazy_load_blob, as bytes
 }
@@ -233,6 +235,13 @@ impl IncomingHttpRequest {
         }
     }
 
+    pub fn bound_path(&self, strip_prefix: Option<&str>) -> String {
+        self
+            .bound_path
+            .replace(strip_prefix.unwrap_or(""), "")
+            .replace("//", "/")
+    }
+
     pub fn path(&self) -> anyhow::Result<String> {
         let url = url::Url::parse(&self.url)?;
         // skip the first path segment, which is the process ID.
@@ -258,6 +267,10 @@ impl IncomingHttpRequest {
             header_map.insert(key_name, value_header);
         }
         header_map
+    }
+
+    pub fn url_params(&self) -> &HashMap<String, String> {
+        &self.url_params
     }
 
     pub fn query_params(&self) -> &HashMap<String, String> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -236,8 +236,7 @@ impl IncomingHttpRequest {
     }
 
     pub fn bound_path(&self, strip_prefix: Option<&str>) -> String {
-        self
-            .bound_path
+        self.bound_path
             .replace(strip_prefix.unwrap_or(""), "")
             .replace("//", "/")
     }


### PR DESCRIPTION
## Problem

Currently, it is possible to bind an HTTP path in `http_server` with a URL param like `/test/:test-id`, but it is not possible to get easy access to `:test-id` or the path that was originally bound.

## Solution

This PR includes the updates to the IncomingHttpRequest, along with additional methods for parsing the `bound_path`

## Docs Update

[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/135)

## Notes

There will be a repo added that can be used to test http bindings and requests.
