### PR TITLE
eth: add chain ID everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,15 +1759,6 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e09bca7d6388637d27fb5edbeab11f56bfabcef8743c55ae34370e1e5030a071"
@@ -1787,18 +1778,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.41.0",
- "wasmparser 0.121.0",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.118.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ee9723b928e735d53000dec9eae7b07a60e490c85ab54abb66659fc61bfcd9"
-dependencies = [
- "indexmap",
- "semver 1.0.21",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1899,8 +1880,8 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.16.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=efcc759#efcc7592cf3277bcb9be1034e48569c6d822b322"
+version = "0.17.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=21a46c7#21a46c774532da99384f7a1877c1fcfb7a4c72d3"
 dependencies = [
  "bitflags",
  "wit-bindgen-rust-macro",
@@ -1908,8 +1889,8 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.16.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=efcc759#efcc7592cf3277bcb9be1034e48569c6d822b322"
+version = "0.17.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=21a46c7#21a46c774532da99384f7a1877c1fcfb7a4c72d3"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -1918,8 +1899,8 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.16.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=efcc759#efcc7592cf3277bcb9be1034e48569c6d822b322"
+version = "0.17.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=21a46c7#21a46c774532da99384f7a1877c1fcfb7a4c72d3"
 dependencies = [
  "anyhow",
  "heck",
@@ -1930,8 +1911,8 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.16.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=efcc759#efcc7592cf3277bcb9be1034e48569c6d822b322"
+version = "0.17.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=21a46c7#21a46c774532da99384f7a1877c1fcfb7a4c72d3"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1944,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.18.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a35a2a9992898c9d27f1664001860595a4bc99d32dd3599d547412e17d7e2"
+checksum = "331de496d439010797c17637d8002712b9b69110f1669164c09dfa226ad277bb"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1955,9 +1936,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.38.1",
+ "wasm-encoder",
  "wasm-metadata",
- "wasmparser 0.118.1",
+ "wasmparser",
  "wit-parser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=098ad56#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=6f8ebb4#6f8ebb45afca1a201a11d421ec46db0f7a1d8d08"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b6fb2b432ff223d513db7f908937f63c252bee0af9b82bfd25b0a5dd1eb0d8"
+checksum = "ef197eb250c64962003cb08b90b17f0882c192f4a6f2f544809d424fd7cb0e7d"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -75,7 +75,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=098ad56#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=6f8ebb4#6f8ebb45afca1a201a11d421ec46db0f7a1d8d08"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -88,10 +88,11 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=098ad56#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=6f8ebb4#6f8ebb45afca1a201a11d421ec46db0f7a1d8d08"
 dependencies = [
  "alloy-json-rpc",
  "base64",
+ "futures-util",
  "serde",
  "serde_json",
  "thiserror",
@@ -619,6 +620,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,9 +643,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1384,6 +1398,15 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ homepage = "https://kinode.org"
 repository = "https://github.com/kinode-dao/process_lib"
 
 [dependencies]
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "098ad56" }
-alloy-primitives = "0.6.2"
-alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "098ad56" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "098ad56" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
+alloy-primitives = "0.6.3"
+alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "6f8ebb4" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "6f8ebb4" }
 anyhow = "1.0"
 bincode = "1.3.3"
 http = "1.0.0"

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -137,390 +137,425 @@ pub enum NodeOrRpcUrl {
     RpcUrl(String),
 }
 
-/// Sends a request based on the specified `EthAction` and parses the response.
-///
-/// This function constructs a request targeting the Ethereum distribution system, serializes the provided `EthAction`,
-/// and sends it. It awaits a response with a specified timeout, then attempts to parse the response into the expected
-/// type `T`. This method is generic and can be used for various Ethereum actions by specifying the appropriate `EthAction`
-/// and return type `T`.
-/// Note the timeout of 5s.
-pub fn send_request_and_parse_response<T: serde::de::DeserializeOwned>(
-    action: EthAction,
-) -> anyhow::Result<T> {
-    let resp = KiRequest::new()
-        .target(("our", "eth", "distro", "sys"))
-        .body(serde_json::to_vec(&action)?)
-        .send_and_await_response(10)??;
+/// An EVM chain provider. Create this object to start making RPC calls.
+/// Set the chain_id to determine which chain to call: requests will fail
+/// unless the node this process is running on has access to a provider
+/// for that chain.
+pub struct Provider {
+    chain_id: u64,
+    request_timeout: u64,
+}
 
-    match resp {
-        Message::Response { body, .. } => {
-            let response = serde_json::from_slice::<EthResponse>(&body)?;
-            match response {
-                EthResponse::Response { value } => serde_json::from_value::<T>(value)
-                    .map_err(|e| anyhow::anyhow!("failed to parse response: {}", e)),
-                _ => Err(anyhow::anyhow!("unexpected response: {:?}", response)),
+impl Provider {
+    /// Sends a request based on the specified `EthAction` and parses the response.
+    ///
+    /// This function constructs a request targeting the Ethereum distribution system, serializes the provided `EthAction`,
+    /// and sends it. It awaits a response with a specified timeout, then attempts to parse the response into the expected
+    /// type `T`. This method is generic and can be used for various Ethereum actions by specifying the appropriate `EthAction`
+    /// and return type `T`.
+    pub fn send_request_and_parse_response<T: serde::de::DeserializeOwned>(
+        &self,
+        action: EthAction,
+    ) -> anyhow::Result<T> {
+        let resp = KiRequest::new()
+            .target(("our", "eth", "distro", "sys"))
+            .body(serde_json::to_vec(&action)?)
+            .send_and_await_response(self.request_timeout)??;
+
+        match resp {
+            Message::Response { body, .. } => {
+                let response = serde_json::from_slice::<EthResponse>(&body)?;
+                match response {
+                    EthResponse::Response { value } => serde_json::from_value::<T>(value)
+                        .map_err(|e| anyhow::anyhow!("failed to parse response: {}", e)),
+                    _ => Err(anyhow::anyhow!("unexpected response: {:?}", response)),
+                }
             }
+            _ => Err(anyhow::anyhow!("unexpected message type: {:?}", resp)),
         }
-        _ => Err(anyhow::anyhow!("unexpected message type: {:?}", resp)),
     }
-}
 
-/// Retrieves the current block number.
-///
-/// # Returns
-/// An `anyhow::Result<u64>` representing the current block number.
-pub fn get_block_number(chain_id: u64) -> anyhow::Result<u64> {
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_blockNumber".to_string(),
-        params: ().into(),
-    };
+    /// Retrieves the current block number.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<u64>` representing the current block number.
+    pub fn get_block_number(&self) -> anyhow::Result<u64> {
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_blockNumber".to_string(),
+            params: ().into(),
+        };
 
-    let res = send_request_and_parse_response::<U64>(action)?;
-    Ok(res.to::<u64>())
-}
+        let res = self.send_request_and_parse_response::<U64>(action)?;
+        Ok(res.to::<u64>())
+    }
 
-/// Retrieves the balance of the given address at the specified block.
-///
-/// # Parameters
-/// - `address`: The address to query the balance for.
-/// - `tag`: Optional block ID to specify the block at which the balance is queried.
-///
-/// # Returns
-/// An `anyhow::Result<U256>` representing the balance of the address.
-pub fn get_balance(chain_id: u64, address: Address, tag: Option<BlockId>) -> anyhow::Result<U256> {
-    let params = serde_json::to_value((
-        address,
-        tag.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
-    ))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getBalance".to_string(),
-        params,
-    };
+    /// Retrieves the balance of the given address at the specified block.
+    ///
+    /// # Parameters
+    /// - `address`: The address to query the balance for.
+    /// - `tag`: Optional block ID to specify the block at which the balance is queried.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<U256>` representing the balance of the address.
+    pub fn get_balance(&self, address: Address, tag: Option<BlockId>) -> anyhow::Result<U256> {
+        let params = serde_json::to_value((
+            address,
+            tag.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)),
+        ))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getBalance".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<U256>(action)
-}
+        self.send_request_and_parse_response::<U256>(action)
+    }
 
-/// Retrieves logs based on a filter.
-///
-/// # Parameters
-/// - `filter`: The filter criteria for the logs.
-///
-/// # Returns
-/// An `anyhow::Result<Vec<Log>>` containing the logs that match the filter.
-pub fn get_logs(chain_id: u64, filter: &Filter) -> anyhow::Result<Vec<Log>> {
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getLogs".to_string(),
-        params: serde_json::to_value((filter,))?,
-    };
+    /// Retrieves logs based on a filter.
+    ///
+    /// # Parameters
+    /// - `filter`: The filter criteria for the logs.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Vec<Log>>` containing the logs that match the filter.
+    pub fn get_logs(&self, filter: &Filter) -> anyhow::Result<Vec<Log>> {
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getLogs".to_string(),
+            params: serde_json::to_value(filter)?,
+        };
 
-    send_request_and_parse_response::<Vec<Log>>(action)
-}
+        self.send_request_and_parse_response::<Vec<Log>>(action)
+    }
 
-/// Retrieves the current gas price.
-///
-/// # Returns
-/// An `anyhow::Result<U256>` representing the current gas price.
-pub fn get_gas_price(chain_id: u64) -> anyhow::Result<U256> {
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_gasPrice".to_string(),
-        params: ().into(),
-    };
+    /// Retrieves the current gas price.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<U256>` representing the current gas price.
+    pub fn get_gas_price(&self) -> anyhow::Result<U256> {
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_gasPrice".to_string(),
+            params: ().into(),
+        };
 
-    send_request_and_parse_response::<U256>(action)
-}
+        self.send_request_and_parse_response::<U256>(action)
+    }
 
-/// Retrieves the number of transactions sent from the given address.
-///
-/// # Parameters
-/// - `address`: The address to query the transaction count for.
-/// - `tag`: Optional block ID to specify the block at which the count is queried.
-///
-/// # Returns
-/// An `anyhow::Result<U256>` representing the number of transactions sent from the address.
-pub fn get_transaction_count(
-    chain_id: u64,
-    address: Address,
-    tag: Option<BlockId>,
-) -> anyhow::Result<U256> {
-    let params = serde_json::to_value((address, tag.unwrap_or_default()))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getTransactionCount".to_string(),
-        params,
-    };
+    /// Retrieves the number of transactions sent from the given address.
+    ///
+    /// # Parameters
+    /// - `address`: The address to query the transaction count for.
+    /// - `tag`: Optional block ID to specify the block at which the count is queried.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<U256>` representing the number of transactions sent from the address.
+    pub fn get_transaction_count(
+        &self,
+        address: Address,
+        tag: Option<BlockId>,
+    ) -> anyhow::Result<U256> {
+        let params = serde_json::to_value((address, tag.unwrap_or_default()))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getTransactionCount".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<U256>(action)
-}
+        self.send_request_and_parse_response::<U256>(action)
+    }
 
-/// Retrieves a block by its hash.
-///
-/// # Parameters
-/// - `hash`: The hash of the block to retrieve.
-/// - `full_tx`: Whether to return full transaction objects or just their hashes.
-///
-/// # Returns
-/// An `anyhow::Result<Option<Block>>` representing the block, if found.
-pub fn get_block_by_hash(
-    chain_id: u64,
-    hash: BlockHash,
-    full_tx: bool,
-) -> anyhow::Result<Option<Block>> {
-    let params = serde_json::to_value((hash, full_tx))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getBlockByHash".to_string(),
-        params,
-    };
+    /// Retrieves a block by its hash.
+    ///
+    /// # Parameters
+    /// - `hash`: The hash of the block to retrieve.
+    /// - `full_tx`: Whether to return full transaction objects or just their hashes.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Option<Block>>` representing the block, if found.
+    pub fn get_block_by_hash(
+        &self,
+        hash: BlockHash,
+        full_tx: bool,
+    ) -> anyhow::Result<Option<Block>> {
+        let params = serde_json::to_value((hash, full_tx))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getBlockByHash".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<Option<Block>>(action)
-}
-/// Retrieves a block by its number or tag.
-///
-/// # Parameters
-/// - `number`: The number or tag of the block to retrieve.
-/// - `full_tx`: Whether to return full transaction objects or just their hashes.
-///
-/// # Returns
-/// An `anyhow::Result<Option<Block>>` representing the block, if found.
-pub fn get_block_by_number(
-    chain_id: u64,
-    number: BlockNumberOrTag,
-    full_tx: bool,
-) -> anyhow::Result<Option<Block>> {
-    let params = serde_json::to_value((number, full_tx))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getBlockByNumber".to_string(),
-        params,
-    };
+        self.send_request_and_parse_response::<Option<Block>>(action)
+    }
+    /// Retrieves a block by its number or tag.
+    ///
+    /// # Parameters
+    /// - `number`: The number or tag of the block to retrieve.
+    /// - `full_tx`: Whether to return full transaction objects or just their hashes.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Option<Block>>` representing the block, if found.
+    pub fn get_block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+        full_tx: bool,
+    ) -> anyhow::Result<Option<Block>> {
+        let params = serde_json::to_value((number, full_tx))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getBlockByNumber".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<Option<Block>>(action)
-}
+        self.send_request_and_parse_response::<Option<Block>>(action)
+    }
 
-/// Retrieves the storage at a given address and key.
-///
-/// # Parameters
-/// - `address`: The address of the storage to query.
-/// - `key`: The key of the storage slot to retrieve.
-/// - `tag`: Optional block ID to specify the block at which the storage is queried.
-///
-/// # Returns
-/// An `anyhow::Result<Bytes>` representing the data stored at the given address and key.
-pub fn get_storage_at(
-    chain_id: u64,
-    address: Address,
-    key: U256,
-    tag: Option<BlockId>,
-) -> anyhow::Result<Bytes> {
-    let params = serde_json::to_value((address, key, tag.unwrap_or_default()))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getStorageAt".to_string(),
-        params,
-    };
+    /// Retrieves the storage at a given address and key.
+    ///
+    /// # Parameters
+    /// - `address`: The address of the storage to query.
+    /// - `key`: The key of the storage slot to retrieve.
+    /// - `tag`: Optional block ID to specify the block at which the storage is queried.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Bytes>` representing the data stored at the given address and key.
+    pub fn get_storage_at(
+        &self,
+        address: Address,
+        key: U256,
+        tag: Option<BlockId>,
+    ) -> anyhow::Result<Bytes> {
+        let params = serde_json::to_value((address, key, tag.unwrap_or_default()))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getStorageAt".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<Bytes>(action)
-}
+        self.send_request_and_parse_response::<Bytes>(action)
+    }
 
-/// Retrieves the code at a given address.
-///
-/// # Parameters
-/// - `address`: The address of the code to query.
-/// - `tag`: The block ID to specify the block at which the code is queried.
-///
-/// # Returns
-/// An `anyhow::Result<Bytes>` representing the code stored at the given address.
-pub fn get_code_at(chain_id: u64, address: Address, tag: BlockId) -> anyhow::Result<Bytes> {
-    let params = serde_json::to_value((address, tag))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getCode".to_string(),
-        params,
-    };
+    /// Retrieves the code at a given address.
+    ///
+    /// # Parameters
+    /// - `address`: The address of the code to query.
+    /// - `tag`: The block ID to specify the block at which the code is queried.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Bytes>` representing the code stored at the given address.
+    pub fn get_code_at(&self, address: Address, tag: BlockId) -> anyhow::Result<Bytes> {
+        let params = serde_json::to_value((address, tag))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getCode".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<Bytes>(action)
-}
+        self.send_request_and_parse_response::<Bytes>(action)
+    }
 
-/// Retrieves a transaction by its hash.
-///
-/// # Parameters
-/// - `hash`: The hash of the transaction to retrieve.
-///
-/// # Returns
-/// An `anyhow::Result<Option<Transaction>>` representing the transaction, if found.
-pub fn get_transaction_by_hash(chain_id: u64, hash: TxHash) -> anyhow::Result<Option<Transaction>> {
-    let params = serde_json::to_value((hash,))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getTransactionByHash".to_string(),
-        params,
-    };
+    /// Retrieves a transaction by its hash.
+    ///
+    /// # Parameters
+    /// - `hash`: The hash of the transaction to retrieve.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Option<Transaction>>` representing the transaction, if found.
+    pub fn get_transaction_by_hash(&self, hash: TxHash) -> anyhow::Result<Option<Transaction>> {
+        let params = serde_json::to_value(hash)?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getTransactionByHash".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<Option<Transaction>>(action)
-}
+        self.send_request_and_parse_response::<Option<Transaction>>(action)
+    }
 
-/// Retrieves the receipt of a transaction by its hash.
-///
-/// # Parameters
-/// - `hash`: The hash of the transaction for which the receipt is requested.
-///
-/// # Returns
-/// An `anyhow::Result<Option<TransactionReceipt>>` representing the transaction receipt, if found.
-pub fn get_transaction_receipt(
-    chain_id: u64,
-    hash: TxHash,
-) -> anyhow::Result<Option<TransactionReceipt>> {
-    let params = serde_json::to_value((hash,))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_getTransactionReceipt".to_string(),
-        params,
-    };
+    /// Retrieves the receipt of a transaction by its hash.
+    ///
+    /// # Parameters
+    /// - `hash`: The hash of the transaction for which the receipt is requested.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Option<TransactionReceipt>>` representing the transaction receipt, if found.
+    pub fn get_transaction_receipt(
+        &self,
+        hash: TxHash,
+    ) -> anyhow::Result<Option<TransactionReceipt>> {
+        let params = serde_json::to_value(hash)?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_getTransactionReceipt".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<Option<TransactionReceipt>>(action)
-}
+        self.send_request_and_parse_response::<Option<TransactionReceipt>>(action)
+    }
 
-/// Estimates the amount of gas that a transaction will consume.
-///
-/// # Parameters
-/// - `tx`: The transaction request object containing the details of the transaction to estimate gas for.
-/// - `block`: Optional block ID to specify the block at which the gas estimate should be made.
-///
-/// # Returns
-/// An `anyhow::Result<U256>` representing the estimated gas amount.
-pub fn estimate_gas(
-    chain_id: u64,
-    tx: TransactionRequest,
-    block: Option<BlockId>,
-) -> anyhow::Result<U256> {
-    let params = serde_json::to_value((tx, block.unwrap_or_default()))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_estimateGas".to_string(),
-        params,
-    };
+    /// Estimates the amount of gas that a transaction will consume.
+    ///
+    /// # Parameters
+    /// - `tx`: The transaction request object containing the details of the transaction to estimate gas for.
+    /// - `block`: Optional block ID to specify the block at which the gas estimate should be made.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<U256>` representing the estimated gas amount.
+    pub fn estimate_gas(
+        &self,
+        tx: TransactionRequest,
+        block: Option<BlockId>,
+    ) -> anyhow::Result<U256> {
+        let params = serde_json::to_value((tx, block.unwrap_or_default()))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_estimateGas".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<U256>(action)
-}
+        self.send_request_and_parse_response::<U256>(action)
+    }
 
-/// Retrieves the list of accounts controlled by the node.
-///
-/// # Returns
-/// An `anyhow::Result<Vec<Address>>` representing the list of accounts.
-/// Note: This function may return an empty list depending on the node's configuration and capabilities.
-pub fn get_accounts(chain_id: u64) -> anyhow::Result<Vec<Address>> {
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_accounts".to_string(),
-        params: serde_json::Value::Array(vec![]),
-    };
+    /// Retrieves the list of accounts controlled by the node.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Vec<Address>>` representing the list of accounts.
+    /// Note: This function may return an empty list depending on the node's configuration and capabilities.
+    pub fn get_accounts(&self) -> anyhow::Result<Vec<Address>> {
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_accounts".to_string(),
+            params: serde_json::Value::Array(vec![]),
+        };
 
-    send_request_and_parse_response::<Vec<Address>>(action)
-}
+        self.send_request_and_parse_response::<Vec<Address>>(action)
+    }
 
-/// Retrieves the fee history for a given range of blocks.
-///
-/// # Parameters
-/// - `block_count`: The number of blocks to include in the history.
-/// - `last_block`: The ending block number or tag for the history range.
-/// - `reward_percentiles`: A list of percentiles to report fee rewards for.
-///
-/// # Returns
-/// An `anyhow::Result<FeeHistory>` representing the fee history for the specified range.
-pub fn get_fee_history(
-    chain_id: u64,
-    block_count: U256,
-    last_block: BlockNumberOrTag,
-    reward_percentiles: Vec<f64>,
-) -> anyhow::Result<FeeHistory> {
-    let params = serde_json::to_value((block_count, last_block, reward_percentiles))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_feeHistory".to_string(),
-        params,
-    };
+    /// Retrieves the fee history for a given range of blocks.
+    ///
+    /// # Parameters
+    /// - `block_count`: The number of blocks to include in the history.
+    /// - `last_block`: The ending block number or tag for the history range.
+    /// - `reward_percentiles`: A list of percentiles to report fee rewards for.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<FeeHistory>` representing the fee history for the specified range.
+    pub fn get_fee_history(
+        &self,
+        block_count: U256,
+        last_block: BlockNumberOrTag,
+        reward_percentiles: Vec<f64>,
+    ) -> anyhow::Result<FeeHistory> {
+        let params = serde_json::to_value((block_count, last_block, reward_percentiles))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_feeHistory".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<FeeHistory>(action)
-}
+        self.send_request_and_parse_response::<FeeHistory>(action)
+    }
 
-/// Executes a call transaction, which is directly executed in the VM of the node, but never mined into the blockchain.
-///
-/// # Parameters
-/// - `tx`: The transaction request object containing the details of the call.
-/// - `block`: Optional block ID to specify the block at which the call should be made.
-///
-/// # Returns
-/// An `anyhow::Result<Bytes>` representing the result of the call.
-pub fn call(
-    chain_id: u64,
-    tx: TransactionRequest,
-    block: Option<BlockId>,
-) -> anyhow::Result<Bytes> {
-    let params = serde_json::to_value((tx, block.unwrap_or_default()))?;
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_call".to_string(),
-        params,
-    };
+    /// Executes a call transaction, which is directly executed in the VM of the node, but never mined into the blockchain.
+    ///
+    /// # Parameters
+    /// - `tx`: The transaction request object containing the details of the call.
+    /// - `block`: Optional block ID to specify the block at which the call should be made.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<Bytes>` representing the result of the call.
+    pub fn call(&self, tx: TransactionRequest, block: Option<BlockId>) -> anyhow::Result<Bytes> {
+        let params = serde_json::to_value((tx, block.unwrap_or_default()))?;
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_call".to_string(),
+            params,
+        };
 
-    send_request_and_parse_response::<Bytes>(action)
-}
+        self.send_request_and_parse_response::<Bytes>(action)
+    }
 
-/// Sends a raw transaction to the network.
-///
-/// # Parameters
-/// - `tx`: The raw transaction data.
-///
-/// # Returns
-/// An `anyhow::Result<TxHash>` representing the hash of the transaction once it has been sent.
-pub fn send_raw_transaction(chain_id: u64, tx: Bytes) -> anyhow::Result<TxHash> {
-    let action = EthAction::Request {
-        chain_id,
-        method: "eth_sendRawTransaction".to_string(),
-        params: serde_json::to_value((tx,))?,
-    };
+    /// Sends a raw transaction to the network.
+    ///
+    /// # Parameters
+    /// - `tx`: The raw transaction data.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<TxHash>` representing the hash of the transaction once it has been sent.
+    pub fn send_raw_transaction(&self, tx: Bytes) -> anyhow::Result<TxHash> {
+        let action = EthAction::Request {
+            chain_id: self.chain_id,
+            method: "eth_sendRawTransaction".to_string(),
+            params: serde_json::to_value(tx)?,
+        };
 
-    send_request_and_parse_response::<TxHash>(action)
-}
+        self.send_request_and_parse_response::<TxHash>(action)
+    }
 
-/// Subscribes to logs without waiting for a confirmation.
-///
-/// # Parameters
-/// - `sub_id`: The subscription ID to be used for unsubscribing.
-/// - `filter`: The filter criteria for the logs.
-///
-/// # Returns
-/// An `anyhow::Result<()>` indicating the operation was dispatched.
-pub fn subscribe(sub_id: u64, chain_id: u64, filter: Filter) -> anyhow::Result<()> {
-    let action = EthAction::SubscribeLogs {
-        sub_id,
-        chain_id,
-        kind: SubscriptionKind::Logs,
-        params: Params::Logs(Box::new(filter)),
-    };
+    /// Subscribes to logs without waiting for a confirmation.
+    ///
+    /// # Parameters
+    /// - `sub_id`: The subscription ID to be used for unsubscribing.
+    /// - `filter`: The filter criteria for the logs.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<()>` indicating whether the subscription was created.
+    pub fn subscribe(&self, sub_id: u64, filter: Filter) -> anyhow::Result<()> {
+        let action = EthAction::SubscribeLogs {
+            sub_id,
+            chain_id: self.chain_id,
+            kind: SubscriptionKind::Logs,
+            params: Params::Logs(Box::new(filter)),
+        };
 
-    KiRequest::new()
-        .target(("our", "eth", "distro", "sys"))
-        .body(serde_json::to_vec(&action)?)
-        .send()
-}
+        let resp = KiRequest::new()
+            .target(("our", "eth", "distro", "sys"))
+            .body(serde_json::to_vec(&action)?)
+            .send_and_await_response(self.request_timeout)??;
 
-/// Unsubscribes from a previously created subscription.
-///
-/// # Parameters
-/// - `sub_id`: The subscription ID to unsubscribe from.
-///
-/// # Returns
-/// An `anyhow::Result<()>` indicating the success or failure of the unsubscription request.
-pub fn unsubscribe(sub_id: u64) -> anyhow::Result<()> {
-    let action = EthAction::UnsubscribeLogs(sub_id);
+        match resp {
+            Message::Response { body, .. } => {
+                let response = serde_json::from_slice::<EthResponse>(&body)?;
+                match response {
+                    EthResponse::Ok => Ok(()),
+                    EthResponse::Response { .. } => {
+                        Err(anyhow::anyhow!("unexpected response: {:?}", response))
+                    }
+                    EthResponse::Err(e) => Err(anyhow::anyhow!("{e:?}")),
+                }
+            }
+            _ => Err(anyhow::anyhow!("unexpected message type: {:?}", resp)),
+        }
+    }
 
-    KiRequest::new()
-        .target(("our", "eth", "distro", "sys"))
-        .body(serde_json::to_vec(&action)?)
-        .send()
+    /// Unsubscribes from a previously created subscription.
+    ///
+    /// # Parameters
+    /// - `sub_id`: The subscription ID to unsubscribe from.
+    ///
+    /// # Returns
+    /// An `anyhow::Result<()>` indicating whether the subscription was cancelled.
+    pub fn unsubscribe(&self, sub_id: u64) -> anyhow::Result<()> {
+        let action = EthAction::UnsubscribeLogs(sub_id);
+
+        let resp = KiRequest::new()
+            .target(("our", "eth", "distro", "sys"))
+            .body(serde_json::to_vec(&action)?)
+            .send_and_await_response(self.request_timeout)??;
+
+        match resp {
+            Message::Response { body, .. } => {
+                let response = serde_json::from_slice::<EthResponse>(&body)?;
+                match response {
+                    EthResponse::Ok => Ok(()),
+                    EthResponse::Response { .. } => {
+                        Err(anyhow::anyhow!("unexpected response: {:?}", response))
+                    }
+                    EthResponse::Err(e) => Err(anyhow::anyhow!("{e:?}")),
+                }
+            }
+            _ => Err(anyhow::anyhow!("unexpected message type: {:?}", resp)),
+        }
+    }
 }

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -147,6 +147,13 @@ pub struct Provider {
 }
 
 impl Provider {
+    /// Instantiate a new provider.
+    pub fn new(chain_id: u64, request_timeout: u64) -> Self {
+        Self {
+            chain_id,
+            request_timeout,
+        }
+    }
     /// Sends a request based on the specified `EthAction` and parses the response.
     ///
     /// This function constructs a request targeting the Ethereum distribution system, serializes the provided `EthAction`,

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -235,7 +235,8 @@ impl Provider {
     /// # Returns
     /// A `Result<Vec<Log>, EthError>` containing the logs that match the filter.
     pub fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>, EthError> {
-        let Ok(params) = serde_json::to_value(filter) else {
+        // NOTE: filter must be encased by a tuple to be serialized correctly
+        let Ok(params) = serde_json::to_value((filter,)) else {
             return Err(EthError::InvalidParams);
         };
         let action = EthAction::Request {
@@ -391,7 +392,8 @@ impl Provider {
     /// # Returns
     /// A `Result<Option<Transaction>, EthError>` representing the transaction, if found.
     pub fn get_transaction_by_hash(&self, hash: TxHash) -> Result<Option<Transaction>, EthError> {
-        let Ok(params) = serde_json::to_value(hash) else {
+        // NOTE: hash must be encased by a tuple to be serialized correctly
+        let Ok(params) = serde_json::to_value((hash,)) else {
             return Err(EthError::InvalidParams);
         };
         let action = EthAction::Request {
@@ -414,7 +416,8 @@ impl Provider {
         &self,
         hash: TxHash,
     ) -> Result<Option<TransactionReceipt>, EthError> {
-        let Ok(params) = serde_json::to_value(hash) else {
+        // NOTE: hash must be encased by a tuple to be serialized correctly
+        let Ok(params) = serde_json::to_value((hash,)) else {
             return Err(EthError::InvalidParams);
         };
         let action = EthAction::Request {
@@ -525,7 +528,8 @@ impl Provider {
         let action = EthAction::Request {
             chain_id: self.chain_id,
             method: "eth_sendRawTransaction".to_string(),
-            params: serde_json::to_value(tx).unwrap(),
+            // NOTE: tx must be encased by a tuple to be serialized correctly
+            params: serde_json::to_value((tx,)).unwrap(),
         };
 
         self.send_request_and_parse_response::<TxHash>(action)

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -17,7 +17,7 @@ use std::collections::HashSet;
 /// capabilities can send this action to the eth provider.
 ///
 /// Will be serialized and deserialized using `serde_json::to_vec` and `serde_json::from_slice`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EthAction {
     /// Subscribe to logs with a custom filter. ID is to be used to unsubscribe.
     /// Logs come in as alloy_rpc_types::pubsub::SubscriptionResults
@@ -70,7 +70,7 @@ pub enum EthResponse {
     Err(EthError),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub enum EthError {
     /// provider module cannot parse message
     MalformedRequest,
@@ -157,14 +157,17 @@ pub struct ProviderConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum NodeOrRpcUrl {
-    Node(crate::kernel_types::KnsUpdate),
+    Node {
+        kns_update: crate::kernel_types::KnsUpdate,
+        use_as_provider: bool, // for routers inside saved config
+    },
     RpcUrl(String),
 }
 
 impl std::cmp::PartialEq<str> for NodeOrRpcUrl {
     fn eq(&self, other: &str) -> bool {
         match self {
-            NodeOrRpcUrl::Node(kns) => kns.name == other,
+            NodeOrRpcUrl::Node { kns_update, .. } => kns_update.name == other,
             NodeOrRpcUrl::RpcUrl(url) => url == other,
         }
     }

--- a/src/kernel_types.rs
+++ b/src/kernel_types.rs
@@ -432,3 +432,14 @@ pub enum MessageType {
     Request,
     Response,
 }
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KnsUpdate {
+    pub name: String, // actual username / domain name
+    pub owner: String,
+    pub node: String, // hex namehash of node
+    pub public_key: String,
+    pub ip: String,
+    pub port: u16,
+    pub routers: Vec<String>,
+}


### PR DESCRIPTION
## Problem

All ETH provider actions need a chain ID, so we can operate on all EVM chains

## Solution

Add `chain_id: u64` to request types ([matching PR in kinode](https://github.com/kinode-dao/kinode/pull/266))

## Docs Update

[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/143)

## Notes

