### PR TITLE
on_exit: use mut ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kinode_process_lib"
 description = "A library for writing Kinode processes in Rust."
-version = "0.8.0"
+version = "0.8.2"
 edition = "2021"
 license-file = "LICENSE"
 homepage = "https://kinode.org"

--- a/src/types/on_exit.rs
+++ b/src/types/on_exit.rs
@@ -64,11 +64,11 @@ impl OnExit {
         }
     }
     /// Add a request to this OnExit if it is Requests, fail otherwise
-    pub fn add_request(self, new: Request) -> anyhow::Result<()> {
+    pub fn add_request(&mut self, new: Request) -> anyhow::Result<()> {
         match self {
             OnExit::None => Err(anyhow::anyhow!("cannot add request to None")),
             OnExit::Restart => Err(anyhow::anyhow!("cannot add request to Restart")),
-            OnExit::Requests(mut reqs) => {
+            OnExit::Requests(ref mut reqs) => {
                 reqs.push(new);
                 Ok(())
             }


### PR DESCRIPTION
## Problem

Ownership issues when using `on_exit::add_request()`. 

## Solution

Use the mutable reference.

## Docs Update

None

## Notes

Add'l context: https://discord.com/channels/1186394868336038080/1250566699112206450