### PR TITLE
match caps impls to core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "alloy",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kinode_process_lib"
 description = "A library for writing Kinode processes in Rust."
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 license-file = "LICENSE"
 homepage = "https://kinode.org"

--- a/src/types/capability.rs
+++ b/src/types/capability.rs
@@ -153,7 +153,8 @@ impl<'a> Deserialize<'a> for Capability {
 impl Hash for Capability {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.issuer.hash(state);
-        self.params.hash(state);
+        let params: serde_json::Value = serde_json::from_str(&self.params).unwrap_or_default();
+        params.hash(state);
     }
 }
 
@@ -161,7 +162,11 @@ impl Eq for Capability {}
 
 impl PartialEq for Capability {
     fn eq(&self, other: &Self) -> bool {
-        self.issuer == other.issuer && self.params == other.params
+        let self_json_params: serde_json::Value =
+            serde_json::from_str(&self.params).unwrap_or_default();
+        let other_json_params: serde_json::Value =
+            serde_json::from_str(&other.params).unwrap_or_default();
+        self.issuer == other.issuer && self_json_params == other_json_params
     }
 }
 


### PR DESCRIPTION
## Problem

We have methods on `Capability` here that don't match core. See e.g. https://github.com/kinode-dao/kinode/pull/434

## Solution

Make them match.

## Docs Update

None

## Notes

Should be merged with core 0.8.3