### PR TITLE
kimap: add derives to contract::Note

### DIFF
--- a/src/kimap.rs
+++ b/src/kimap.rs
@@ -59,6 +59,7 @@ pub mod contract {
         /// - labelhash: The hash of only the label (the final entry in the path).
         /// - label: The label of the note.
         /// - data: The data stored at the note.
+        #[derive(std::hash::Hash, PartialEq, Eq)]
         event Note(
             bytes32 indexed parenthash,
             bytes32 indexed notehash,


### PR DESCRIPTION
## Problem

I want to use a Note as a HashMap key

## Solution

Derive

## Docs Update

None

## Notes

None