### PR TITLE
develop v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "alloy",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kinode_process_lib"
 description = "A library for writing Kinode processes in Rust."
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license-file = "LICENSE"
 homepage = "https://kinode.org"


### PR DESCRIPTION
## Problem

1. `vfs::open_dir()` with `!create` always returns `Ok` even when dir does not exist.

## Solution

1. Check if dir exists.

## Docs Update

None

## Notes

None