### PR TITLE
vfs: open_or_create

### DIFF
--- a/src/vfs/directory.rs
+++ b/src/vfs/directory.rs
@@ -88,6 +88,17 @@ pub fn open_dir(path: &str, create: bool, timeout: Option<u64>) -> Result<Direct
     }
 }
 
+/// Open or create a directory at path.
+pub fn open_or_create_dir(path: &str) -> Result<Directory, VfsError> {
+    match open_dir(path, false, None) {
+        Ok(dir) => Ok(dir),
+        Err(_) => match open_dir(path, true, None) {
+            Ok(dir) => Ok(dir),
+            Err(e) => Err(e),
+        },
+    }
+}
+
 /// Removes a dir at path, errors if path not found or path is not a directory.
 pub fn remove_dir(path: &str, timeout: Option<u64>) -> Result<(), VfsError> {
     let timeout = timeout.unwrap_or(5);

--- a/src/vfs/directory.rs
+++ b/src/vfs/directory.rs
@@ -67,7 +67,7 @@ pub fn open_dir(path: &str, create: bool, timeout: Option<u64>) -> Result<Direct
         });
     }
 
-    let message = vfs_request(path, VfsAction::CreateDir)
+    let message = vfs_request(path, VfsAction::CreateDirAll)
         .send_and_await_response(timeout)
         .unwrap()
         .map_err(|e| VfsError::IOError {
@@ -85,17 +85,6 @@ pub fn open_dir(path: &str, create: bool, timeout: Option<u64>) -> Result<Direct
             error: "unexpected response".to_string(),
             path: path.to_string(),
         }),
-    }
-}
-
-/// Open or create a directory at path.
-pub fn open_or_create_dir(path: &str) -> Result<Directory, VfsError> {
-    match open_dir(path, false, None) {
-        Ok(dir) => Ok(dir),
-        Err(_) => match open_dir(path, true, None) {
-            Ok(dir) => Ok(dir),
-            Err(e) => Err(e),
-        },
     }
 }
 

--- a/src/vfs/file.rs
+++ b/src/vfs/file.rs
@@ -377,6 +377,17 @@ pub fn open_file(path: &str, create: bool, timeout: Option<u64>) -> Result<File,
     }
 }
 
+/// Open or create a file at path.
+pub fn open_or_create_file(path: &str) -> Result<File, VfsError> {
+    match open_file(path, false, None) {
+        Ok(file) => Ok(file),
+        Err(_) => match open_file(path, true, None) {
+            Ok(file) => Ok(file),
+            Err(e) => Err(e),
+        },
+    }
+}
+
 /// Creates a file at path, if file found at path, truncates it to 0.
 pub fn create_file(path: &str, timeout: Option<u64>) -> Result<File, VfsError> {
     let timeout = timeout.unwrap_or(5);

--- a/src/vfs/file.rs
+++ b/src/vfs/file.rs
@@ -377,17 +377,6 @@ pub fn open_file(path: &str, create: bool, timeout: Option<u64>) -> Result<File,
     }
 }
 
-/// Open or create a file at path.
-pub fn open_or_create_file(path: &str) -> Result<File, VfsError> {
-    match open_file(path, false, None) {
-        Ok(file) => Ok(file),
-        Err(_) => match open_file(path, true, None) {
-            Ok(file) => Ok(file),
-            Err(e) => Err(e),
-        },
-    }
-}
-
 /// Creates a file at path, if file found at path, truncates it to 0.
 pub fn create_file(path: &str, timeout: Option<u64>) -> Result<File, VfsError> {
     let timeout = timeout.unwrap_or(5);


### PR DESCRIPTION
## Problem

We have a create flag passed to our usual `open_dir` and `open_file` methods. This corresponds to the API in `std::fs` and `tokio::fs` like here: 

```rust
tokio::fs::OpenOptions::new()
  .read(true)
  .write(true)
  .create(create)
```

Now, if you pass a create(true) to a file that already exists, it will fail with a FileAlreadyExists error. 
We could match on this specific error in core/vfs.rs, but I think rather than that, have a helper function here that makes 2 calls.
## Solution
`vfs::open_or_create_file/dir` helpers that first try opening a file/dir with create: false, then create:true. 
## Docs Update

[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/my-pr-number)

## Notes

{Any other information useful for reviewers.}
