### PR TITLE
vfs: file drop file is close

### DIFF
--- a/src/vfs/file.rs
+++ b/src/vfs/file.rs
@@ -20,6 +20,12 @@ impl File {
         }
     }
 
+    fn drop(&self) {
+        vfs_request(&self.path, VfsAction::CloseFile)
+            .send()
+            .unwrap();
+    }
+
     /// Reads the entire file, from start position.
     /// Returns a vector of bytes.
     pub fn read(&self) -> Result<Vec<u8>, VfsError> {

--- a/src/vfs/file.rs
+++ b/src/vfs/file.rs
@@ -20,12 +20,6 @@ impl File {
         }
     }
 
-    fn drop(&self) {
-        vfs_request(&self.path, VfsAction::CloseFile)
-            .send()
-            .unwrap();
-    }
-
     /// Reads the entire file, from start position.
     /// Returns a vector of bytes.
     pub fn read(&self) -> Result<Vec<u8>, VfsError> {
@@ -326,6 +320,14 @@ impl File {
                 path: self.path.clone(),
             }),
         }
+    }
+}
+
+impl Drop for File {
+    fn drop(&mut self) {
+        vfs_request(&self.path, VfsAction::CloseFile)
+            .send()
+            .unwrap();
     }
 }
 


### PR DESCRIPTION
## Problem

We run out of file descriptors. Work is ongoing to fix this at an OS level, but we should also clean up after ourselves: close files in VFS on drop.

## Solution

On drop, `CloseFile`.

## Docs Update

None

## Notes

None