### PR TITLE
add `Spawn!()` noop macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ pub fn get_capability(issuer: &Address, params: &str) -> Option<Capability> {
 /// The `Spawn!()` macro is defined here as a no-op.
 /// However, in practice, `kit build` will rewrite it during pre-processing.
 ///
-/// Example:
+/// Examples:
 /// ```no_run
 /// fn init(our: Address) {
 ///     let parent = our.clone();
@@ -328,8 +328,20 @@ pub fn get_capability(issuer: &Address, params: &str) -> Option<Capability> {
 ///    the generated child and send a [`Request()`] to pass in the closure's args.
 /// 3. Update the relevant metadata for the package
 ///    (i.e. `Cargo.toml`, `metadata.json`, etc.).
+///
+///
+/// ```no_run
+/// fn init(our: Address) {
+///     let parent = our.clone();
+///     Spawn!(my_function(parent));
+///     ...
+/// }
+/// ```
 #[macro_export]
 macro_rules! Spawn {
-    // Match one or more type-annotated parameters
+    // Pattern 1: Match closure with type-annotated parameters
     (|$($param:ident : $type:ty),+ $(,)?| $body:block) => {};
+
+    // Pattern 2: Match function call
+    ($fn_name:ident($($arg:expr),* $(,)?)) => {};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,3 +307,31 @@ pub fn get_capability(issuer: &Address, params: &str) -> Option<Capability> {
         cap.issuer == *issuer && params == cap_params
     })
 }
+
+/// The `Spawn!()` macro is defined here as a no-op.
+/// However, in practice, `kit build` will rewrite it during pre-processing.
+///
+/// Example:
+/// ```no_run
+/// fn init(our: Address) {
+///     Spawn!(|our| {
+///         println!("hello from {our}. I am Spawn of {}!", args["our"]);
+///     });
+///     ...
+/// }
+/// ```
+/// will be rewritten by `kit build` to:
+/// 1. Generate a new child process within the package that, here, `println!()`s,
+///    or, in general, executes the code given by the closure.
+/// 2. Replace the code lines in the parent process with [`spawn()`] to start
+///    the generated child and send a [`Request()`] to pass in the closure's args.
+/// 3. Update the relevant metadata for the package
+///    (i.e. `Cargo.toml`, `metadata.json`, etc.).
+#[macro_export]
+macro_rules! Spawn {
+    // Matches a closure with one parameter
+    (|$param:ident| $body:block) => {};
+
+    // If you also need to support multiple parameters in the closure:
+    (|$($param:ident),*| $body:block) => {};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,7 +372,7 @@ macro_rules! Spawn {
         )*
     ) => {{
         // Validate each key at compile time using nested macro
-        validate_spawn_args!($($key),*);
+        $crate::validate_spawn_args!($($key),*);
 
         // Your implementation here
     }};
@@ -386,7 +386,7 @@ macro_rules! Spawn {
         )*
     ) => {{
         // Validate each key at compile time using nested macro
-        validate_spawn_args!($($key),*);
+        $crate::validate_spawn_args!($($key),*);
 
         // Your implementation here
     }};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,8 @@ pub fn get_capability(issuer: &Address, params: &str) -> Option<Capability> {
 /// Example:
 /// ```no_run
 /// fn init(our: Address) {
-///     Spawn!(|our| {
+///     let parent = our.clone();
+///     Spawn!(|parent: Address| {
 ///         println!("hello from {our}. I am Spawn of {}!", args["our"]);
 ///     });
 ///     ...
@@ -329,9 +330,6 @@ pub fn get_capability(issuer: &Address, params: &str) -> Option<Capability> {
 ///    (i.e. `Cargo.toml`, `metadata.json`, etc.).
 #[macro_export]
 macro_rules! Spawn {
-    // Matches a closure with one parameter
-    (|$param:ident| $body:block) => {};
-
-    // If you also need to support multiple parameters in the closure:
-    (|$($param:ident),*| $body:block) => {};
+    // Match one or more type-annotated parameters
+    (|$($param:ident : $type:ty),+ $(,)?| $body:block) => {};
 }


### PR DESCRIPTION
## Problem

When we `Spawn()` (e.g. see [here](https://github.com/kinode-dao/kit/pull/275#issuecomment-2487143232)) the linter/analyzer gets mad because that function doesn't exist.

## Solution

Add a noop macro, `Spawn!()`. We'll replace this instead of `Spawn()`, but then the linter will be happy and display whatever docs we write on it.

## Docs Update

None yet.

## Notes

Connected to https://github.com/kinode-dao/kit/pull/275