### PR TITLE
request,response: add `attach_all()` method

### DIFF
--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -1,5 +1,6 @@
 use crate::{Address, Capability, LazyLoadBlob, ProcessId};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// The basic `Message` type.
 /// A `Message` is either a [`crate::Request`] or a [`crate::Response`].
@@ -26,22 +27,13 @@ pub enum Message {
     },
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum BuildError {
+    #[error("no body set for message")]
     NoBody,
+    #[error("no target set for message")]
     NoTarget,
 }
-
-impl std::fmt::Display for BuildError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            BuildError::NoBody => write!(f, "no body set for message"),
-            BuildError::NoTarget => write!(f, "no target set for  message"),
-        }
-    }
-}
-
-impl std::error::Error for BuildError {}
 
 impl Message {
     /// Get the `source` [`Address`] of a `Message`.

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -34,7 +34,7 @@ impl Request {
             capabilities: vec![],
         }
     }
-    /// Start building a new Request with the `target` [`Address`]. In order
+    /// Start building a new `Request` with the `target` [`Address`]. In order
     /// to successfully send, you must still fill out at least the `body` field
     /// by calling [`Request::body()`] or [`Request::try_body()`] next.
     pub fn to<T>(target: T) -> Self
@@ -52,7 +52,7 @@ impl Request {
             capabilities: vec![],
         }
     }
-    /// Set the target [`Address`] that this request will go to.
+    /// Set the `target` [`Address`] that this `Request` will go to.
     pub fn target<T>(mut self, target: T) -> Self
     where
         T: Into<Address>,
@@ -241,6 +241,13 @@ impl Request {
             params: "\"messaging\"".to_string(),
         }]);
         self
+    }
+    /// Attach all capabilities we have that were issued by `target` (if set) to the next message.
+    pub fn try_attach_all(mut self) -> Result<Self, BuildError> {
+        let Some(ref target) = self.target else {
+            return Err(BuildError::NoTarget);
+        };
+        Ok(self.attach_all(target))
     }
     /// Attach all capabilities we have that were issued by `target` to the next message.
     pub fn attach_all(mut self, target: &Address) -> Self {

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -235,14 +235,14 @@ impl Request {
         self
     }
     /// Attach the [`Capability`] to message this process to the next message.
-    pub fn attach_messaging(mut self, our: &Address) {
+    pub fn attach_messaging(mut self, our: &Address) -> Self {
         self.capabilities.extend(vec![Capability {
             issuer: our.clone(),
             params: "\"messaging\"".to_string(),
         }]);
     }
     /// Attach all capabilities we have that were issued by `target` to the next message.
-    pub fn attach_all(mut self, target: &Address) {
+    pub fn attach_all(mut self, target: &Address) -> Self {
         let target = target.clone();
         self.capabilities.extend(
             our_capabilities()

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Address, Capability, LazyLoadBlob, Message, SendError, _wit_message_to_message,
-    _wit_send_error_to_send_error, types::message::BuildError,
+    our_capabilities, Address, Capability, LazyLoadBlob, Message, SendError,
+    _wit_message_to_message, _wit_send_error_to_send_error, types::message::BuildError,
 };
 
 /// `Request` builder. Use [`Request::new()`] or [`Request::to()`] to start a request,
@@ -240,6 +240,16 @@ impl Request {
             issuer: our.clone(),
             params: "\"messaging\"".to_string(),
         }]);
+    }
+    /// Attach all capabilities we have that were issued by `target` to the next message.
+    pub fn attach_all(mut self, target: &Address) {
+        let target = target.clone();
+        self.capabilities.extend(
+            our_capabilities()
+                .into_iter()
+                .filter(|cap| cap.issues == target)
+                .collect(),
+        );
     }
     /// Attempt to send the `Request`. This will only fail if the `target` or `body`
     /// fields have not been set.

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -240,6 +240,7 @@ impl Request {
             issuer: our.clone(),
             params: "\"messaging\"".to_string(),
         }]);
+        self
     }
     /// Attach all capabilities we have that were issued by `target` to the next message.
     pub fn attach_all(mut self, target: &Address) -> Self {
@@ -247,9 +248,10 @@ impl Request {
         self.capabilities.extend(
             our_capabilities()
                 .into_iter()
-                .filter(|cap| cap.issues == target)
+                .filter(|cap| cap.issuer == target)
                 .collect(),
         );
+        self
     }
     /// Attempt to send the `Request`. This will only fail if the `target` or `body`
     /// fields have not been set.

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -249,7 +249,7 @@ impl Request {
             our_capabilities()
                 .into_iter()
                 .filter(|cap| cap.issuer == target)
-                .collect(),
+                .collect::<Vec<_>>(),
         );
         self
     }

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -1,4 +1,4 @@
-use crate::{our_capabilities, types::message::BuildError, Capability, LazyLoadBlob};
+use crate::{our_capabilities, types::message::BuildError, Address, Capability, LazyLoadBlob};
 
 /// `Response` builder. Use [`Response::new()`] to start a `Response`, then build it,
 /// then call [`Response::send()`] on it to fire.
@@ -159,6 +159,7 @@ impl Response {
                 .filter(|cap| cap.issues == target)
                 .collect(),
         );
+        self
     }
     /// Attempt to send the `Response`. This will only fail if the IPC body field of
     /// the `Response` has not yet been set using `body()` or `try_body()`.

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -151,7 +151,7 @@ impl Response {
         self
     }
     /// Attach all capabilities we have that were issued by `target` to the next message.
-    pub fn attach_all(mut self, target: &Address) {
+    pub fn attach_all(mut self, target: &Address) -> Self {
         let target = target.clone();
         self.capabilities.extend(
             our_capabilities()

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -1,4 +1,4 @@
-use crate::{types::message::BuildError, Capability, LazyLoadBlob};
+use crate::{our_capabilities, types::message::BuildError, Capability, LazyLoadBlob};
 
 /// `Response` builder. Use [`Response::new()`] to start a `Response`, then build it,
 /// then call [`Response::send()`] on it to fire.
@@ -149,6 +149,16 @@ impl Response {
     pub fn capabilities(mut self, capabilities: Vec<Capability>) -> Self {
         self.capabilities = capabilities;
         self
+    }
+    /// Attach all capabilities we have that were issued by `target` to the next message.
+    pub fn attach_all(mut self, target: &Address) {
+        let target = target.clone();
+        self.capabilities.extend(
+            our_capabilities()
+                .into_iter()
+                .filter(|cap| cap.issues == target)
+                .collect(),
+        );
     }
     /// Attempt to send the `Response`. This will only fail if the IPC body field of
     /// the `Response` has not yet been set using `body()` or `try_body()`.

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -150,6 +150,13 @@ impl Response {
         self.capabilities = capabilities;
         self
     }
+    /// Attach all capabilities we have that were issued by `target` (if set) to the next message.
+    pub fn try_attach_all(mut self) -> Result<Self, BuildError> {
+        let Some(ref target) = self.target else {
+            return Err(BuildError::NoTarget);
+        };
+        Ok(self.attach_all(target))
+    }
     /// Attach all capabilities we have that were issued by `target` to the next message.
     pub fn attach_all(mut self, target: &Address) -> Self {
         let target = target.clone();

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -156,8 +156,8 @@ impl Response {
         self.capabilities.extend(
             our_capabilities()
                 .into_iter()
-                .filter(|cap| cap.issues == target)
-                .collect(),
+                .filter(|cap| cap.issuer == target)
+                .collect::<Vec<_>>(),
         );
         self
     }


### PR DESCRIPTION
## Problem

https://github.com/kinode-dao/kinode/issues/581

## Solution

Make use of the pattern from https://github.com/kinode-dao/kinode/pull/596 in a process_lib method.

## Docs Update

None

## Notes

None