### PR TITLE
Set response body

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1080,16 +1080,6 @@ impl HttpServer {
 
 /// Send an HTTP response to an incoming HTTP request ([`HttpServerRequest::Http`]).
 pub fn send_response(status: StatusCode, headers: Option<HashMap<String, String>>, body: Vec<u8>) {
-    // Check if there's a manual body override in the HTTP context
-    let final_body = crate::hyperapp::APP_HELPERS.with(|helpers| {
-        helpers
-            .borrow()
-            .current_http_context
-            .as_ref()
-            .and_then(|ctx| ctx.response_body.clone())
-            .unwrap_or(body) // Use override if present, otherwise use the parameter
-    });
-
     KiResponse::new()
         .body(
             serde_json::to_vec(&HttpResponse {
@@ -1098,7 +1088,7 @@ pub fn send_response(status: StatusCode, headers: Option<HashMap<String, String>
             })
             .unwrap(),
         )
-        .blob_bytes(final_body)
+        .blob_bytes(body)
         .send()
         .unwrap()
 }

--- a/src/hyperapp.rs
+++ b/src/hyperapp.rs
@@ -43,7 +43,6 @@ pub struct HttpRequestContext {
     pub request: IncomingHttpRequest,
     pub response_headers: HashMap<String, String>,
     pub response_status: http::StatusCode,
-    pub response_body: Option<Vec<u8>>,
 }
 
 pub struct AppContext {
@@ -144,15 +143,6 @@ pub fn set_response_status(status: http::StatusCode) {
     })
 }
 
-// Set the HTTP response body directly (bypasses Result serialization)
-pub fn set_response_body(body: Vec<u8>) {
-    APP_HELPERS.with(|helpers| {
-        if let Some(ctx) = &mut helpers.borrow_mut().current_http_context {
-            ctx.response_body = Some(body);
-        }
-    })
-}
-
 pub fn clear_http_request_context() {
     APP_HELPERS.with(|helpers| {
         helpers.borrow_mut().current_http_context = None;
@@ -171,30 +161,10 @@ pub fn source() -> Address {
     })
 }
 
-/// Get query parameters from the current HTTP request path (manually parsed)
-/// Returns None if not in an HTTP context or no query parameters present
-/// NOTE: This manually parses the path string. For pre-parsed params, use get_parsed_query_params()
-pub fn get_query_params() -> Option<HashMap<String, String>> {
-    get_path().map(|path| {
-        let mut params = HashMap::new();
-        if let Some(query_start) = path.find('?') {
-            let query = &path[query_start + 1..];
-            for pair in query.split('&') {
-                if let Some(eq_pos) = pair.find('=') {
-                    let key = pair[..eq_pos].to_string();
-                    let value = pair[eq_pos + 1..].to_string();
-                    params.insert(key, value);
-                }
-            }
-        }
-        params
-    })
-}
-
 /// Get the pre-parsed query parameters from the current HTTP request
 /// Returns None if not in an HTTP context
 /// This accesses the query_params field that Hyperware already parsed (includes URL decoding)
-pub fn get_parsed_query_params() -> Option<HashMap<String, String>> {
+pub fn get_query_params() -> Option<HashMap<String, String>> {
     APP_HELPERS.with(|helpers| {
         helpers
             .borrow()


### PR DESCRIPTION
## Problem

In the HTTP server, results are serialized into a format such that any HTTP response is wrapped in a `{ok : {actual content}}` format. So if any external thing is sensitive to the format of the response's body, it will fail outright because it doesn't handle that when decomposing the body JSON.

## Solution

Introduces a check before sending off a `final_body` HTTP response for an optional manual override that replaces the usual Result serialization with some declared raw body value, as well as a Hyperapp function to invoke it. This change should be completely backwards compatible since if there is no raw body value declared it passes through the serialized result as usual.

## Docs Update

lmfao

## Notes

This PR was written entirely by Claude Sonnet 4.5 (with vigorous guidance from me, but still)
